### PR TITLE
Updated test script to pass string to mocha

### DIFF
--- a/packages/generator-slimer/generators/test/index.js
+++ b/packages/generator-slimer/generators/test/index.js
@@ -1,8 +1,8 @@
 'use strict';
 const Generator = require('../../lib/Generator');
 
-// "test": "NODE_ENV=testing mocha ./test/**/*.test.js",
-const testScript = 'NODE_ENV=testing mocha ./test/**/*.test.js';
+// "test": "NODE_ENV=testing mocha './test/**/*.test.js'",
+const testScript = 'NODE_ENV=testing mocha \'./test/**/*.test.js\'';
 
 const knownOptions = {
     type: {


### PR DESCRIPTION
no-issue

This is because the shell will try to expand the glob if it's not
wrapped in strings, which can give different outcomes depending on the
globbing supporting by the shell. Passing a string will allow mocha to
sort out globbing which is more predictable.

Related issue is here: https://github.com/mochajs/mocha/issues/1828