### PR TITLE
Keep older version of beeper for themes

### DIFF
--- a/packages/renovate-config/package.json
+++ b/packages/renovate-config/package.json
@@ -193,7 +193,13 @@
         "@tryghost:groupCSS"
       ],
       "automerge": true,
-      "automergeType": "branch"
+      "automergeType": "branch",
+      "packageRules": [
+        {
+          "matchPackageNames": ["beeper"],
+          "allowedVersions": "<3.0.0"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
[beeper](https://github.com/sindresorhus/beeper)'s recently been updated to `3.0.0` and started requiring `import beeper from 'beeper'` syntax from that version. This caused an error for gulp tasks saying `Error [ERR_REQUIRE_ESM]: Must use import to load ES Module`.

This PR adds `allowedVersions` setting to the global renovate config of themes to prevent it from being updated to `v3` automatically.