### PR TITLE
Increased test coverage requirement to 100%

### DIFF
--- a/packages/generator-slimer/generators/test/index.js
+++ b/packages/generator-slimer/generators/test/index.js
@@ -1,8 +1,8 @@
 'use strict';
 const Generator = require('../../lib/Generator');
 
-// "test": "NODE_ENV=testing c8 --all --check-coverage --reporter text --reporter cobertura mocha './test/**/*.test.js'",
-const testScript = 'NODE_ENV=testing c8 --all --check-coverage --reporter text --reporter cobertura mocha \'./test/**/*.test.js\'';
+// "test": "NODE_ENV=testing c8 --all --check-coverage --100 --reporter text --reporter cobertura mocha './test/**/*.test.js'",
+const testScript = 'NODE_ENV=testing c8 --all --check-coverage --100  --reporter text --reporter cobertura mocha \'./test/**/*.test.js\'';
 
 const knownOptions = {
     type: {


### PR DESCRIPTION
refs https://github.com/TryGhost/Toolbox/issues/487

- We are aiming to have 100% test coverage in our codebase - that should be a default starting point for every new package.
- In case there's a valid reason to change these numbers they can be tweaked in the package's package.json test command configuration

@daniellockyer I rarely touch this bit of codebase, so wanted to check if any other bits need to change with this bump? Also, I'll push out a change to the default test files generated because when I was trying out the new flow it's a frustrating experience removing "should" dependencies and adding the "assert" require at the top. I do not aim to make it perfect just to get the initial frustration out of the way so getting to that 100% is easy 