### PR TITLE
Use renovate-config repo directly for Renovate presets

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "renovate": {
     "extends": [
-      "@tryghost:quietJS"
+      "github>TryGhost/renovate-config"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- replace package-style `@tryghost:` preset usage with `github>TryGhost/renovate-config`
- standardize shared Renovate configuration on the dedicated renovate-config repository
- remove indirection from older preset reference patterns